### PR TITLE
Automatic update of NUnit.ConsoleRunner to 3.9.0

### DIFF
--- a/test/KnightMovesTests.csproj
+++ b/test/KnightMovesTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.8.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NUnit.ConsoleRunner` to `3.9.0` from `3.8.0`
`NUnit.ConsoleRunner 3.9.0` was published at `2018-09-06T00:38:00Z`, 3 months ago

1 project update:
Updated `test/KnightMovesTests.csproj` to `NUnit.ConsoleRunner` `3.9.0` from `3.8.0`

[NUnit.ConsoleRunner 3.9.0 on NuGet.org](https://www.nuget.org/packages/NUnit.ConsoleRunner/3.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
