### PR TITLE
Automatic update of Moq to 4.10.0

### DIFF
--- a/test/KnightMovesTests.csproj
+++ b/test/KnightMovesTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.5.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Moq" Version="4.9.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Moq` to `4.10.0` from `4.9.0`
`Moq 4.10.0` was published at `2018-09-08T10:21:58Z`, 3 months ago

1 project update:
Updated `test/KnightMovesTests.csproj` to `Moq` `4.10.0` from `4.9.0`

[Moq 4.10.0 on NuGet.org](https://www.nuget.org/packages/Moq/4.10.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
