### PR TITLE
Automatic update of Microsoft.NET.Test.Sdk to 15.9.0

### DIFF
--- a/test/KnightMovesTests.csproj
+++ b/test/KnightMovesTests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="NUnit" Version="3.10.1" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.8.0" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.NET.Test.Sdk` to `15.9.0` from `15.7.0`
`Microsoft.NET.Test.Sdk 15.9.0` was published at `2018-10-10T05:32:52Z`, 2 months ago

1 project update:
Updated `test/KnightMovesTests.csproj` to `Microsoft.NET.Test.Sdk` `15.9.0` from `15.7.0`

[Microsoft.NET.Test.Sdk 15.9.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.NET.Test.Sdk/15.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
